### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,8 @@ jobs:
 
   deploy-staging:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.ref == 'refs/heads/develop'
     needs: [release]
 


### PR DESCRIPTION
Potential fix for [https://github.com/sjefsharp/agentic_crypto_influencer/security/code-scanning/4](https://github.com/sjefsharp/agentic_crypto_influencer/security/code-scanning/4)

To fix the problem, explicitly restrict the permissions available to the `deploy-staging` job. This will override the inherited permissions and ensure the job only receives the level of access it requires. Since the job does not push changes, publish packages, or interact with the repository in write mode, it is safest to set the minimal permission: `contents: read`. 

This change should be made directly in `.github/workflows/cd.yml`, by adding a `permissions` block just under `runs-on: ubuntu-latest` (line 59) in the `deploy-staging` job. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
