### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,6 +91,7 @@ jobs:
 
   deploy-staging:
     runs-on: ubuntu-latest
+    permissions: {}
     if: github.ref == 'refs/heads/develop'
     needs: [build_and_test]
 
@@ -108,6 +109,7 @@ jobs:
 
   deploy-production:
     runs-on: ubuntu-latest
+    permissions: {}
     if: github.event_name == 'release'
     needs: [build_and_test]
 


### PR DESCRIPTION
Potential fix for [https://github.com/sjefsharp/agentic_crypto_influencer/security/code-scanning/11](https://github.com/sjefsharp/agentic_crypto_influencer/security/code-scanning/11)

To fix the issue, we must explicitly define a `permissions` block in both the `deploy-staging` and `deploy-production` jobs. If these jobs do not interact with the GitHub API (i.e., do not need to push commits, create releases, open issues, etc.), the most secure setting is `permissions: {}` which disables the token entirely for those jobs. This should be set at the same level as `runs-on:` in each job, just as in the `build_and_test` job. No other job functionality will be affected, as GitHub-recommended actions like `actions/download-artifact` do not require the token.  
Thus, in `.github/workflows/cd.yml`, add `permissions: {}` to both of those jobs between `runs-on: ...` and `if: ...`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
